### PR TITLE
Creation timestamp is sometimes zero or too big.

### DIFF
--- a/messengerexif.py
+++ b/messengerexif.py
@@ -177,9 +177,7 @@ def format_timestamp(timestamp):
 
 def normalize_json(obj, timestamp=None):
     if "creation_timestamp" in obj:
-        if timestamp is None:
-                timestamp = obj["creation_timestamp"]
-        timestamp = normalize_timestamp(timestamp)
+        timestamp = normalize_timestamp(obj["creation_timestamp"] if timestamp is None else timestamp)
         obj["creation_timestamp"] = normalize_timestamp(obj["creation_timestamp"])
         if  obj["creation_timestamp"] == 0:
             print(f"WARNING: `creation_timestamp` is zero, using message `timestamp` instead: {obj}")


### PR DESCRIPTION
This PR handles when the creation timestamp is bigger than the message timestamp (54 times) and when it is zero (11 times). In both cases, those values make no sense, so the message timestamp is used instead. 

Both of these scenarios are rare, collectively I ran into this issue 65 times out of 8723 images. For some reason, these issues largely occurred for photos taken in 2013 or 2014.

I noticed this originally when I found images from 2013 that had a creation timestamp in 2015??? I found out Facebook's data sometimes makes no sense.