### PR TITLE
Fix wrong (and confusing) exiftool path error

### DIFF
--- a/messengerexif.py
+++ b/messengerexif.py
@@ -81,7 +81,7 @@ def main():
         sys.exit(1)
     exiftool_path = Path(args.exiftool).absolute()
     if not exiftool_path.exists():
-        print(f'Path "{str(folder_path)}" does not exist!')
+        print(f'Path "{str(exiftool_path)}" does not exist!')
         print("Exiting.")
         sys.exit(1)
     backup = args.backup


### PR DESCRIPTION
Inputing a wrong exitftool path leads the script to output an error message showing the folder path. I think I have identified the error in the code, and I hope that this is the correct way to fix it.